### PR TITLE
add: allow initContainers as sidecar container

### DIFF
--- a/facilitator/assets/exams/ckad/001/scripts/validation/q6_s1_validate_multicontainer_pod.sh
+++ b/facilitator/assets/exams/ckad/001/scripts/validation/q6_s1_validate_multicontainer_pod.sh
@@ -11,9 +11,14 @@ fi
 # Verify container names
 NGINX_CONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.containers[?(@.name=="nginx")].name}' 2>/dev/null)
 SIDECAR_CONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.containers[?(@.name=="sidecar")].name}' 2>/dev/null)
+SIDECAR_INITCONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.initContainers[?(@.name=="sidecar")].name}' 2>/dev/null)
+SIDECAR_INITCONTAINER_CONDITION=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.initContainers[?(@.name=="sidecar")].restartPolicy}' 2>/dev/null)
 
 if [ -n "$NGINX_CONTAINER" ] && [ -n "$SIDECAR_CONTAINER" ]; then
     echo "Success: Pod has both 'nginx' and 'sidecar' containers"
+    exit 0
+elif [ -n "$NGINX_CONTAINER" ] && [ -n "$SIDECAR_INITCONTAINER" ] && [ "$SIDECAR_INITCONTAINER_CONDITION" = "Always" ]; then
+    echo "Success: Pod has 'nginx' container and 'sidecar' init container with restartPolicy 'Always'"
     exit 0
 else
     echo "Error: Pod does not have the required container names ('nginx' and 'sidecar')"


### PR DESCRIPTION
#### 🧾 What this PR does
This PR extends the validation logic for the CKAD-001-q6.

#### 🧩 Type of change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [x] Other (please describe): add ability to check for (new) sidecar container 

---

#### 🧪 How to test it

Create two Pods, validate with validation script -> should return 'Success..' in both scenarios. 
The 'old' and the 'new' way:

Old:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sidecar-pod
  namespace: troubleshooting
spec:
  containers:
  - name: nginx
    image: nginx
    volumeMounts:
    - name: log-volume
      mountPath: /var/my-log
  - name: sidecar
    image: busybox
    command: ["sh", "-c", "while true; do date >> /var/my-log/date.log; sleep 10; done"]
    volumeMounts:
    - name: log-volume
      mountPath: /var/my-log
  volumes:
  - name: log-volume
    emptyDir: {}
```

new:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sidecar-pod
  namespace: troubleshooting
spec:
  containers:
  - name: nginx
    image: nginx
    volumeMounts:
    - name: log-volume
      mountPath: /var/my-log
  initContainers:
  - name: sidecar
    image: busybox
    restartPolicy: Always
    command: ["sh", "-c", "while true; do date >> /var/my-log/date.log; sleep 10; done"]
    volumeMounts:
    - name: log-volume
      mountPath: /var/my-log
  volumes:
  - name: log-volume
    emptyDir: {}
```

validation:
```sh
#!/bin/bash

# Validate if the pod 'sidecar-pod' exists in the 'troubleshooting' namespace and has containers named 'nginx' and 'sidecar'
POD_EXISTS=$(kubectl get pod sidecar-pod -n troubleshooting -o name 2>/dev/null)

if [ -z "$POD_EXISTS" ]; then
    echo "Error: Pod 'sidecar-pod' does not exist in namespace 'troubleshooting'"
    exit 1
fi

# Verify container names
NGINX_CONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.containers[?(@.name=="nginx")].name}' 2>/dev/null)
SIDECAR_CONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.containers[?(@.name=="sidecar")].name}' 2>/dev/null)
SIDECAR_INITCONTAINER=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.initContainers[?(@.name=="sidecar")].name}' 2>/dev/null)
SIDECAR_INITCONTAINER_CONDITION=$(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.initContainers[?(@.name=="sidecar")].restartPolicy}' 2>/dev/null)

if [ -n "$NGINX_CONTAINER" ] && [ -n "$SIDECAR_CONTAINER" ]; then
    echo "Success: Pod has both 'nginx' and 'sidecar' containers"
    exit 0
elif [ -n "$NGINX_CONTAINER" ] && [ -n "$SIDECAR_INITCONTAINER" ] && [ "$SIDECAR_INITCONTAINER_CONDITION" = "Always" ]; then
    echo "Success: Pod has 'nginx' container and 'sidecar' init container with restartPolicy 'Always'"
    exit 0
else
    echo "Error: Pod does not have the required container names ('nginx' and 'sidecar')"
    echo "Found containers with names: $(kubectl get pod sidecar-pod -n troubleshooting -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)"
    exit 1
fi
```

#### ✅ Acceptance Criteria
- [ ] Pod starts without errors  
- [ ] Docker Compose logs are available  
- [x] All relevant tests pass  
- [ ] Documentation is updated (if needed - usually it is)

<!-- If you are adding labs, please, also add the following -->

- [ ] New labs pass  
- [ ] Answers work as expected  

#### 🧠 Additional Context

The [k8s docs](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) allow sidecar containers as initContainers 

`FEATURE STATE: Kubernetes v1.33 [stable] (enabled by default: true)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation checks to also accept pods with an "nginx" container and a "sidecar" init container as valid configurations.
  * Enhanced success conditions for pod verification in the troubleshooting namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->