### PR TITLE
fix: Change port exposure definition when host and container port matches

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
       context: ./remote-desktop
     hostname: terminal
     expose:
-      - "5901"  # VNC port (internal only)
-      - "6901"  # Web VNC port (internal only)
+      - "5901" # VNC port (internal only)
+      - "6901" # Web VNC port (internal only)
     environment:
       - VNC_PW=bakku-the-wizard
       - VNC_PASSWORD=bakku-the-wizard
@@ -21,10 +21,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
+          cpus: "1"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
     networks:
       - ckx-network
@@ -35,7 +35,7 @@ services:
     build:
       context: ./app
     expose:
-      - "3000"  # Only exposed to internal network
+      - "3000" # Only exposed to internal network
     environment:
       - VNC_SERVICE_HOST=remote-desktop
       - VNC_SERVICE_PORT=6901
@@ -47,10 +47,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.2'
+          cpus: "0.2"
           memory: 256M
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:3000/"]
@@ -72,14 +72,14 @@ services:
       - facilitator
       - k8s-api-server
     ports:
-      - "30080:80"  # Expose Nginx on port 30080
+      - "30080:80" # Expose Nginx on port 30080
     deploy:
       resources:
         limits:
-          cpus: '0.2'
+          cpus: "0.2"
           memory: 256M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 128M
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]
@@ -98,15 +98,15 @@ services:
     privileged: true
     # No external port mappings - only accessible internally
     expose:
-      - "22"  # SSH port (internal only)
+      - "22" # SSH port (internal only)
     volumes:
-      - kube-config:/home/candidate/.kube  # Shared volume for Kubernetes config
+      - kube-config:/home/candidate/.kube # Shared volume for Kubernetes config
     deploy:
       resources:
         limits:
-          cpus: '1'
+          cpus: "1"
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
     networks:
       - ckx-network
@@ -115,7 +115,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      
+
   # Remote Terminal Service
   remote-terminal:
     image: nishanb/ck-x-simulator-remote-terminal:latest
@@ -123,14 +123,14 @@ services:
       context: ./remote-terminal
     hostname: remote-terminal
     expose:
-      - "22"  # SSH port (internal only)
+      - "22" # SSH port (internal only)
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.2'
+          cpus: "0.2"
           memory: 256M
     networks:
       - ckx-network
@@ -139,27 +139,27 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      
+
   # KIND Kubernetes Cluster
-  k8s-api-server:  # Service name that will be used for DNS resolution
+  k8s-api-server: # Service name that will be used for DNS resolution
     image: nishanb/ck-x-simulator-cluster:latest
     build:
       context: ./kind-cluster
     container_name: kind-cluster
     hostname: k8s-api-server
-    privileged: true  # Required for running containers inside KIND
+    privileged: true # Required for running containers inside KIND
     expose:
-      - "6443:6443" 
+      - "6443"
       - "22"
     volumes:
-      - kube-config:/home/candidate/.kube  # Shared volume for Kubernetes config
+      - kube-config:/home/candidate/.kube # Shared volume for Kubernetes config
     deploy:
       resources:
         limits:
-          cpus: '2'
+          cpus: "2"
           memory: 4G
         reservations:
-          cpus: '1'
+          cpus: "1"
           memory: 2G
     networks:
       - ckx-network
@@ -183,10 +183,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.3'
+          cpus: "0.3"
           memory: 256M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 128M
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -222,10 +222,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.2'
+          cpus: "0.2"
           memory: 256M
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:3000"]
@@ -239,4 +239,4 @@ networks:
     driver: bridge
 
 volumes:
-  kube-config:  # Shared volume for Kubernetes configuration
+  kube-config: # Shared volume for Kubernetes configuration


### PR DESCRIPTION
- Fixed port exposure definition for k8s-api-server in docker-compose.yaml
- Automatically converted single quotes for numbers to double qoutes for consistency

<!-- Title of the PR:

Example: `fix: Update volume mount path in CKAD 001 Q6`

-->

---

#### 🧾 What this PR does

The port exposure definition for the k8s-api-server container was defunct as it was exposing port 6443 on the host to port 6443 on the container.

It is questionable if we want the k8s-api-server to be reachable by the host. Is that what we want?

    expose:
      - "6443:6443" 
      - "22"

This causes issues as some compose engines are interpreting it as a port range definition.

---

#### 🧩 Type of change

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (please describe): ____________

---

#### 🧪 How to test it

<!-- Provide clear, step-by-step instructions for testing this change.

This fix should need no specific test, as it uses the standard port exposure definition.

-->

---

#### ✅ Acceptance Criteria

<!-- Tick each box once the corresponding criterion is met.

Feel free to add or remove items depending on what your PR changes.

-->

- [x] Pod starts without errors  
- [ ] Docker Compose logs are available  
- [ ] All relevant tests pass  
- [ ] Documentation is updated (if needed - usually it is)

<!-- If you are adding labs, please, also add the following -->

- [ ] New labs pass  
- [ ] Answers work as expected  

---

#### 📎 Related Issue(s)

<!-- Mention any related issues.

Example: "Closes #42" or "Refs #15"

-->

---

#### 💬 Notes for Reviewers

<!-- Add any extra context or notes for the reviewer.  

Example: "I also tweaked the wording of the exercise to explicitly define container names."

-->

Some chores were automatically done in the process

- Whitespace trimming
- Quote consistency cleanup

---

#### 🧠 Additional Context

<!--

Add any background or technical context that might help reviewers understand the motivation or constraints of the PR.

-->

The motivation was to allow users of Podman Compose to use the docker-compose manifest.

---

#### 📄 Attachments

<!-- Add any relevant attachments such as:  

- Screenshots of the labs list showing the the newly added labs
- Screenshots of the labs running
- Screenshots of the labs passing
- E2E test results (screenshots or, preferably, logs/human-readable reports)
- Static code analysis reports
- Any other supporting material (e.g. logs, error traces, terminal output)

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated API server port exposure to internal-only (removed host mapping). Access from the host on port 6443 is no longer available; other services within the stack can still reach it. Update any local access workflows accordingly.
- Style
  - Standardized quoting (single to double) for CPU values.
  - Trimmed extra spaces and normalized comment spacing across services.
  - These formatting changes do not alter runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->